### PR TITLE
feat: Easier entry point using bench commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,6 @@ jobs:
         working-directory: /home/runner/frappe-bench/sites
         run: |
           bench --site test_site set-config allow_tests true
-          source ../env/bin/activate
-          ../apps/caffeine/caffeine/microbenchmarks/run_benchmarks.py --site test_site -l2 -p2 -w0 --quiet
+          bench --site test_site run-microbenchmarks -l2 -p2 -w0 --quiet
         env:
           TYPE: server

--- a/caffeine/commands/__init__.py
+++ b/caffeine/commands/__init__.py
@@ -1,0 +1,32 @@
+import subprocess
+
+import click
+from frappe.commands import pass_context
+from frappe.exceptions import SiteNotSpecifiedError
+
+
+@click.command(
+	"run-microbenchmarks",
+	context_settings=dict(
+		ignore_unknown_options=True,
+	),
+	add_help_option=False,
+)
+@click.argument("benchargs", nargs=-1, type=click.UNPROCESSED)
+@pass_context
+def run_benchmarks(ctx, benchargs):
+	if not ctx.sites:
+		raise SiteNotSpecifiedError
+	site = ctx.sites[0]
+	benchargs = ("--site", site) + benchargs
+
+	from caffeine.microbenchmarks import run_benchmarks
+
+	# XXX: We can't invoke it directly pyperf wants to be the entry point
+	# Anyway, this shouldn't be a problem. It's no different than shell invoking it.
+	subprocess.check_call(["../env/bin/python3", run_benchmarks.__file__, *benchargs])
+
+
+commands = [
+	run_benchmarks,
+]


### PR DESCRIPTION
Use `bench --site sitename run-microbenchmarks` to run all benchmarks.

Use `--filter=substring` to filter benchmarks. There are no other custom
flags, rest are inherited from `pyperf`.

Use `bench --site sitename run-microbenchmarks --help` or refer to https://pyperf.readthedocs.io/
